### PR TITLE
feat: increased timeout limit, should reduce API exception

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -267,4 +267,4 @@ def rollback(message: telebot.types.Message) -> None:
 
 
 if __name__ == "__main__":
-    bot.infinity_polling()
+    bot.infinity_polling(timeout=10, long_polling_timeout=5)


### PR DESCRIPTION
This change should reduce the number of API exceptions encountered. Such exceptions are generated by the telebot code itself and cannot be catched and managed in the repo's code. For this reason the best option found so far is to increase the timeout limit for API calls, this means that timeout reads exceptions should become rarer. Such changes should partially solve [this](https://github.com/Fabio11111999/score_bot/issues/14) issue. I'll leave such issue open since this in only a partial solution